### PR TITLE
Add retry count to the response

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -3,5 +3,6 @@
     "trailingComma": "all",
     "singleQuote": true,
     "printWidth": 120,
-    "tabWidth": 4
+    "tabWidth": 4,
+    "endOfLine": "auto"
 }

--- a/src/test/unit/index.test.ts
+++ b/src/test/unit/index.test.ts
@@ -14,10 +14,11 @@ describe('fetch builder', (): void => {
         mockedFetch.mockResolvedValueOnce(new Response('503', { status: 503 }));
         mockedFetch.mockResolvedValueOnce(new Response('504', { status: 504 }));
 
-        const response = await f('https://example.test');
-
-        expect(response).toMatchObject({ status: 503, retryCount: 0 });
-        expect(mockedFetch.mock.calls.length).toBe(1);
+        return expect(f('https://example.test'))
+            .resolves.toMatchObject({ status: 503, retryCount: 0 })
+            .then((): void => {
+                expect(mockedFetch.mock.calls.length).toBe(1);
+            });
     });
 });
 


### PR DESCRIPTION
This PR would resolve the feature request of #790.

Added two interfaces for the returning of the Response and Error. Added the variable `retryCount` to the response to return the amount of retries done for a request. Appended the tests to include the checking of the correct amount of retries.